### PR TITLE
Fix ghc 8.4.x build errors

### DIFF
--- a/Atavachron.cabal
+++ b/Atavachron.cabal
@@ -11,6 +11,8 @@ Build-Type:      Simple
 
 Library
   Hs-Source-Dirs:  src
+  if impl(ghc < 8.0)
+   Build-Depends:  semigroups
   Build-Depends:   base, containers, hashable, mtl, parsec, wl-pprint,
                    unordered-containers, directory, filepath, random,
                    time, text, streaming, unix, exceptions, bytestring,
@@ -52,6 +54,8 @@ Executable atavachron
   Main-Is:         Main.hs
   Buildable: True
   Hs-Source-Dirs:  src
+  if impl(ghc < 8.0)
+   Build-Depends:  semigroups
   Build-Depends:   base, containers, hashable, mtl, parsec, wl-pprint,
                    unordered-containers, directory, filepath, random,
                    time, text, streaming, unix, exceptions, bytestring,

--- a/src/Atavachron/Chunk/Builder.hs
+++ b/src/Atavachron/Chunk/Builder.hs
@@ -28,6 +28,7 @@ import qualified Data.ByteString.Builder as BB
 import Streaming.Prelude (next)
 import qualified Streaming.Prelude as S
 
+import Data.Semigroup (Semigroup (..))
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 
@@ -44,6 +45,10 @@ data Builder t = Builder
   , bTaggedOffsets :: !(TaggedOffsets t)
   , bSize          :: !Int
   }
+
+instance Semigroup (Builder t) where
+  Builder bb1 ts1 s1 <> Builder bb2 ts2 s2 =
+    Builder (bb1 <> bb2) (ts1 <> ts2) (s1 + s2)
 
 instance Monoid (Builder t) where
     mempty = Builder mempty mempty 0

--- a/src/Atavachron/Pipelines.hs
+++ b/src/Atavachron/Pipelines.hs
@@ -42,6 +42,7 @@ import Data.Time.Clock
 
 import qualified Data.List as List
 
+import Data.Semigroup (Semigroup(..))
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 
@@ -572,7 +573,7 @@ verifyChunks str = do
 
 newtype VerifyResult = VerifyResult
     { vrErrors :: Seq (Error FileItem)
-    } deriving (Show, Monoid)
+    } deriving (Show, Semigroup, Monoid)
 
 summariseErrors
     :: (MonadState Progress m, MonadIO m)


### PR DESCRIPTION
Since Semigroup is a super class of Monoid from GHC 8.0 onwards, we explicitly depend on semigroup package for ghc < 8.0 and also derive a Semigroup instance for a few data types for which Monoid instance is defined.

(Very interesting project, btw. I learned a bunch of things reading the code. Looking forward to meet you during HaskellX.)